### PR TITLE
Reconnect to ssh tunnel every minute instead of every 10 minutes.

### DIFF
--- a/cron-scripts/reverse-tunnel.sh
+++ b/cron-scripts/reverse-tunnel.sh
@@ -6,6 +6,6 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
 
 while : ; do
 ssh -N -T -R 33333:localhost:22 -i ./.ssh/<YOUR KEY> -o ServerAliveInterval=3 -o StrictHostKeyChecking=no <USER>@<YOUR SERVER>
-sleep 600
+sleep 60
 done
 


### PR DESCRIPTION
If you are using an ssh tunnel instead of openvpn, you probably don't want to wait so long for a reconnect.