### PR TITLE
Screenshot fixes

### DIFF
--- a/src/scripts/email-screenshots.sh
+++ b/src/scripts/email-screenshots.sh
@@ -13,15 +13,14 @@ m_pwd="yoursender_password"
 m_file="/tmp/imgmail.html"
 m_data="/tmp/imgmail.txt"
 
-# Save the backlight to a variable, set it to 100, then set it back after imgur.sh ?
 bklght=$(lv GUI_backlightUserRequest)
-sdv GUI_backlightUserRequest 100
+sdv GUI_backlightUserRequest 255 && sleep 1
 CID=$(curl -s http://cid:4070/screenshot)
-sleep 2
 IC=$(curl -s http://ic:4130/screenshot)
-sleep 2
+sdv GUI_backlightUserRequest ${bklght//\"}
 CIDPATH=$(get_path_from_screenshot "$CID")
 ICPATH=$(get_path_from_screenshot "$IC")
+sleep 1
 scp -rp root@ic:"$ICPATH" /home/tesla/.Tesla/data/screenshots/
 
 echo "<html>
@@ -93,5 +92,3 @@ rm $m_file
 rm $m_data
 rm $CIDPATH
 rm $ICPATH
-sleep 3
-sdv GUI_backlightUserRequest $bklght

--- a/src/scripts/upload-screenshots.sh
+++ b/src/scripts/upload-screenshots.sh
@@ -12,13 +12,14 @@ get_path_from_screenshot() {
 }
 
 bklght=$(lv GUI_backlightUserRequest)
-sdv GUI_backlightUserRequest 100
+sdv GUI_backlightUserRequest 255 && sleep 1
 CID=$(curl -s http://cid:4070/screenshot)
-sleep 2
 IC=$(curl -s http://ic:4130/screenshot)
-sleep 2
+sdv GUI_backlightUserRequest ${bklght//\"}
 CIDPATH=$(get_path_from_screenshot "$CID")
-ICPATH=$(get_path_from_screenshot "$IC")
-scp -rp root@ic:"$ICPATH" /home/tesla/.Tesla/data/screenshots/
-sdv GUI_backlightUserRequest $bklght
+if [ "$IC" != "" ]; then # ic may be sleeping (energy savings mode)
+    ICPATH=$(get_path_from_screenshot "$IC")
+    sleep 1
+    scp -rp root@ic:"$ICPATH" /home/tesla/.Tesla/data/screenshots/
+fi
 bash $imgurAPI $CIDPATH $ICPATH


### PR DESCRIPTION
- fixed wrong brightness for screenshot and added necessary delay for it to take effect
- fixed restoring original brightness didn't work ($bklight must not contain quotes)
- fixed IC screenshots sometimes were corrupted (transferred before flushed)
- skip IC screenshots if it's sleeping (imgur script only since email script would become a bit messy)