### PR TITLE
VNC: support for intel, Model 3, new firmware

### DIFF
--- a/src/scripts/misc/vnc-remote-control.sh
+++ b/src/scripts/misc/vnc-remote-control.sh
@@ -14,18 +14,19 @@
 CHROOT="/home/tesla/alpine3.11"
 
 function mountStuff() {
-    mount -o remount,exec /home # need this to allow execution on /home
+    mount -o remount,exec,suid,symfollow /home # need this to allow execution on /home
     mount -o bind /dev ${CHROOT}/dev
     mount -o bind /proc ${CHROOT}/proc
     mount -t sysfs archsys ${CHROOT}/sys
     mount -o bind /tmp ${CHROOT}/tmp
     mount -t devpts archdevpts ${CHROOT}/dev/pts
-    mount /var -o remount,exec
+    mount /var -o remount,exec,suid,symfollow
     mount -o bind /var ${CHROOT}/var
 }
 
 if [ ! -d "$CHROOT" ]; then
-    ALPINE_URI="http://dl-cdn.alpinelinux.org/alpine/v3.11/releases/armhf/alpine-minirootfs-3.11.3-armhf.tar.gz"
+    ARCH=$(uname -m)
+    ALPINE_URI="http://dl-cdn.alpinelinux.org/alpine/v3.11/releases/$ARCH/alpine-minirootfs-3.11.3-$ARCH.tar.gz"
     curl -O ${ALPINE_URI}
     mkdir -p ${CHROOT}
     tar -zxvf $(basename ${ALPINE_URI}) -C ${CHROOT}
@@ -40,14 +41,27 @@ else
     mountStuff
 fi
 
+VERTICAL_DISPLAY=true
+ROTATION=90
+if [[ "$(< /var/etc/chassistype)" == "Model3"]]; then
+    VERTICAL_DISPLAY=false
+    ROTATION=0
+fi
+
 if [ ! -f "/var/captureClicks.sh" ]; then
-    cat > /var/captureClicks.sh <<'EOF'
+    cat > /var/captureClicks.sh << 'EOF'
 #!/bin/bash
+EOF << "VERTICAL_DISPLAY=${VERTICAL_DISPLAY}" << 'EOF'
 
 while read line; do
     if [[ "$line" == *ButtonPress* ]]; then
         y=$(echo $line | cut -d " " -f 3)
-        x=$((1200 - $(echo $line | cut -d " " -f 4)))
+        x=$(echo $line | cut -d " " -f 4)
+
+        if [ "$VERTICAL_DISPLAY" == true ]; then
+            x=$((1200 - $x))
+        fi
+
         curl -s "http://cid:4070/injectMouseEvent?action=down&x=$x&y=$y&id=0"
         sleep 0.1
         curl -s "http://cid:4070/injectMouseEvent?action=release&x=$x&y=$y&id=0"
@@ -62,5 +76,5 @@ cat <<EOF | chroot ${CHROOT} /bin/bash
     xauth generate :0 . trusted
     xauth add ${HOST}:0 . $(xxd -l 16 -p /dev/urandom)
     xauth list
-    x11vnc -noipv6 -display :0 -nopw -rfbport 5900 -rotate 90 -cursor none -nodragging -pipeinput "/var/captureClicks.sh"
+    DISPLAY=:0 x11vnc -noipv6 -display :0 -nopw -rotate ${ROTATION} -rfbport 5900 -nodragging -pipeinput "/var/captureClicks.sh"
 EOF


### PR DESCRIPTION
Adds support for intel Model 3Y and SX.
Also adds "suid,symfollow" to /home & /var, to run on the newest Tesla firmware.
I don't have the opportunity to test it on a Model SX, especially on a Tegra.
Maybe you should leave both versions if no one can test?

